### PR TITLE
refactor: streamline user auth checks and switch from flash to query …

### DIFF
--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -3,6 +3,13 @@
 {% block title %}Log In{% endblock %} 
 
 {% block content %}
+{% if message %}
+<div class="alert alert-warning alert-dismissible fade show" role="alert">
+  {{ message }}
+  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>
+{% endif %}
+
 <div class="row justify-content-center">
     <div class="col-md-6 col-lg-5">
 


### PR DESCRIPTION
…messages to avoid setting secret_key for now

- Moved current user logic into @before_request for reuse across routes
- Updated @context_processor to pull from `g` for cleaner template injection
- Replaced flash() with URL query parameters to avoid requiring secret_key (temporary)
- Adjusted /my_books and /login routes to handle messages using ?message=
- Removed redundant checks like `if g.current_user` when `g.username` is sufficient
- Prepared for optional alert box display via Bootstrap in templates