### PR TITLE
fix(upload_book): restore book info after validation error (server si…

### DIFF
--- a/app/static/js/book-upload.js
+++ b/app/static/js/book-upload.js
@@ -531,4 +531,17 @@ document.addEventListener('DOMContentLoaded', function() {
     
     
     updateFormVisibility();
+
+    if (openlibraryIdInput?.value && titleInput?.value && authorInput?.value) {
+        const restoredBookInfo = {
+            key: openlibraryIdInput.value,
+            title: titleInput.value,
+            authors: authorInput.value,
+            pages: totalPagesInput?.value || '',
+            cover: coverImageInput?.value || ''
+        };
+
+        populateFormFromBook(restoredBookInfo);
+    }
+
 });


### PR DESCRIPTION
…de) on resubmission

earlier when you submitted with end date before start date and you used the API search, with the error it would lose the cover image and let users type in title and author. Fixed now so it will maintain that information